### PR TITLE
Add object style 'set' call

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ qb.insert(values)
 
 #### <a name="ChangeLog"></a>ChangeLog
 
+- 1.4.0
+  - Add support for object style `set` calls; e.g. `.set(<Object := {<String>: <Mixed>, ...}>)`.
 - 1.3.0
   - Add support for the DataStax driver `eachRow` method.
 - 1.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassanknex",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "An Apache Cassandra CQL query builder with support for the DataStax NodeJS driver, written in the spirit of Knex.",
   "main": "index.js",
   "homepage": "https://github.com/azuqua/cassanknex",

--- a/query/queryBuilder.js
+++ b/query/queryBuilder.js
@@ -72,13 +72,30 @@ function _getWhere(type) {
 function _getSet(type) {
   return function (identifier, value) {
 
-    var statement = {
-      grouping: "set",
-      type: type,
-      key: identifier,
-      val: value
-    };
-    this._statements.push(statement);
+    // object type 'set' called => .set(<Object> := {<String>: <Mixed>, ...})
+    if (_.isObject(identifier)) {
+      var self = this;
+      _.each(identifier, function (value, identifier) {
+
+        var statement = {
+          grouping: "set",
+          type: type,
+          key: identifier,
+          val: value
+        };
+        self._statements.push(statement);
+      });
+    }
+    // simple 'set' called => .set(<String>, <Mixed>)
+    else {
+      var statement = {
+        grouping: "set",
+        type: type,
+        key: identifier,
+        val: value
+      };
+      this._statements.push(statement);
+    }
 
     return this;
   };

--- a/tests/queries.test.js
+++ b/tests/queries.test.js
@@ -132,4 +132,19 @@ describe("QueryMethods", function () {
     var _cql = qb.cql();
     assert(_cql === cql, "Expected compilation: '" + cql + "' but compiled: " + _cql);
   });
+  it("should compile an update query string using an object param", function () {
+
+    var cql = "UPDATE cassanKnexy.columnFamily SET bar = ?,foo = ? WHERE foo[bar] = ? AND id in (?, ?, ?, ?, ?);"
+      , qb = cassanKnex("cassanKnexy");
+    qb.update("columnFamily")
+      .set({
+        "bar": "baz",
+        "foo": ["bar", "baz"]
+      })
+      .where("foo[bar]", "=", "baz")
+      .where("id", "in", ["1", "1", "2", "3", "5"]);
+
+    var _cql = qb.cql();
+    assert(_cql === cql, "Expected compilation: '" + cql + "' but compiled: " + _cql);
+  });
 });


### PR DESCRIPTION
`set` can now be called using a single object as the function parameter; e.g.

```
var qb = cassanknex("keyspaceName")
  .update("columnFamilyName")
  .set({ "foo": "bar", "baz": ["foo", "bar"] });
```