### PR TITLE
Add truncate column family functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 A [fully tested][travis-url] Apache Cassandra CQL query builder with support for the DataStax NodeJS driver, written in the spirit of [Knex][knexjs-url] for [CQL 3.1.x][cassandra-cql-3_1-ref-url].
 
+## Installation
+
+```
+npm install cassanknex
+```
+
 ## Index
 
 - [Why CassanKnex](#WhyCassanknex)
@@ -478,13 +484,14 @@ qb.insert(values)
 - alterColumnFamily
 - createColumnFamily
 - createColumnFamilyIfNotExists
-- dropColumnFamily
-- dropColumnFamilyIfExists
 - createIndex
 - createType
 - createTypeIfNotExists
+- dropColumnFamily
+- dropColumnFamilyIfExists
 - dropType
 - dropTypeIfExists
+- truncate
 
 ##### <a name="QueryCommands-Keyspaces"></a>*For keyspace queries*:
 - alterKeyspace
@@ -547,6 +554,8 @@ qb.insert(values)
 
 #### <a name="ChangeLog"></a>ChangeLog
 
+- 1.9.0
+  - Add `truncate` functionality.
 - 1.8.0
   - Add `batch` execution functionality per the specifications laid out in issue [#19](https://github.com/azuqua/cassanknex/issues/19).
 - 1.7.1

--- a/componentDeclarations/componentCompilerMethods.js
+++ b/componentDeclarations/componentCompilerMethods.js
@@ -23,8 +23,9 @@ module.exports = {
     "createType": "createType",
     "createTypeIfNotExists": "createTypeIfNotExists",
     "dropType": "dropType",
-    "dropTypeIfExists": "dropTypeIfExists"
+    "dropTypeIfExists": "dropTypeIfExists",
 
+    "truncate": "truncate"
   },
   "query": {
     "delete": "delete",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "author": "austin brown <austin@azuqua.com> (http://www.azuqua.com/)",
   "license": "MIT",
   "dependencies": {
-    "cassandra-driver": "^2.0.1",
+    "cassandra-driver": "^2.2.1",
     "inherits": "^2.0.1",
-    "lodash": "^3.7.0"
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/schema/columnFamilyCompiler.js
+++ b/schema/columnFamilyCompiler.js
@@ -95,6 +95,9 @@ module.exports = {
     arguments[2] = true;
     arguments.length = 3;
     return this._wrapMethod(component, "dropTypeIfExists", _getDropType(), arguments);
+  },
+  truncate: function () {
+    return this._wrapMethod(component, "truncate", _getTruncate(), arguments);
   }
 };
 
@@ -289,10 +292,12 @@ function _getDropType() {
       ifNot: ifNot
     });
 
-    if (compiling.value.columnFamily)
+    if (compiling.value.columnFamily) {
       this._setColumnFamily(compiling.value.columnFamily);
-    if (compiling.value.keyspace)
+    }
+    if (compiling.value.keyspace) {
       this._setKeyspace(compiling.value.keyspace);
+    }
 
     var dropStatement = compiling.value.ifNot ? "DROP TYPE IF EXISTS " : "DROP TYPE "
       , cql = dropStatement + [formatter.wrapQuotes(this.keyspace()), this.columnFamily()].join(".") + " ";
@@ -305,6 +310,33 @@ function _getDropType() {
     return this;
   };
 
+}
+
+function _getTruncate() {
+
+  return function (columnFamily) {
+
+    var compiling = this.getCompiling("truncate", {
+      columnFamily: columnFamily
+    });
+
+    if (compiling.value.columnFamily) {
+      this._setColumnFamily(compiling.value.columnFamily);
+    }
+    if (compiling.value.keyspace) {
+      this._setKeyspace(compiling.value.keyspace);
+    }
+
+    var truncateStatement = "TRUNCATE " +
+      [formatter.wrapQuotes(this.keyspace()), formatter.wrapQuotes(this.columnFamily())].join(".") +
+      " ;";
+
+    this.query({
+      cql: truncateStatement
+    });
+
+    return this;
+  };
 }
 
 function _compileColumns(client, deliminator, wrap) {

--- a/tests/columnFamily.test.js
+++ b/tests/columnFamily.test.js
@@ -257,4 +257,16 @@ describe("ColumnFamilyMethods", function () {
     var _cql = qb.cql();
     assert(_cql === cql, "Expected compilation: '" + cql + "' but compiled: " + _cql);
   });
+
+  // TRUNCATE
+
+  it("should compile a truncate column family statement", function () {
+
+    var cql = 'TRUNCATE "cassanKnexy"."columnFamily" ;'
+      , qb = cassanKnex("cassanKnexy")
+        .truncate("columnFamily");
+
+    var _cql = qb.cql();
+    assert(_cql === cql, "Expected compilation: '" + cql + "' but compiled: " + _cql);
+  });
 });

--- a/tests/live/live.test.js
+++ b/tests/live/live.test.js
@@ -243,6 +243,16 @@ describe("yolo", function () {
             assert(resp.rowLength === 0, "All rows must be deleted!");
             next(err);
           });
+      },
+      // test the truncate execution
+      function (next) {
+
+        var qb = cassanKnex(keyspace)
+          .truncate(columnFamily)
+          .exec(function (err, resp) {
+            assert(!err, err);
+            next(err);
+          });
       }
     ], function (err) {
 


### PR DESCRIPTION
Allows compiling statements of the form `TRUNCATE "keyspace"."columnFamily" ;` via:
```js
qb = cassanKnex("keyspace")
        .truncate("columnFamily");
```