### PR TITLE
v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ npm install cassanknex
     - [Rows](#QueryModifiers-Rows)
     - [Column Families](#QueryModifiers-ColumnFamilies)
     - [Keyspaces](#QueryModifiers-Keyspaces)
+  - [Utility Methods](#UtilityMethods)
 - [ChangeLog](#ChangeLog)
 
 ## <a name="WhyCassanknex"></a>Why (what's in a name)
@@ -552,6 +553,30 @@ qb.insert(values)
 - withNetworkTopologyStrategy
 - withSimpleStrategy
 - withDurableWrites
+
+#### <a name="UtilityMethods"></a>Utility Methods
+
+- getClient, returns the Datastax Cassandra Driver in use.
+
+```js
+var cassanKnex = require("cassanknex")({
+  connection: {
+    contactPoints: ["10.0.0.2"]
+  }
+});
+
+cassanKnex.on("ready", function (err) {
+
+  if (err)
+    console.error("Error Connecting to Cassandra Cluster", err);
+  else {
+    console.log("Cassandra Connected");
+
+    // get the Cassandra Driver
+    var client = cassanKnex.getClient();
+  }
+});
+```
 
 #### <a name="ChangeLog"></a>ChangeLog
 

--- a/README.md
+++ b/README.md
@@ -555,6 +555,8 @@ qb.insert(values)
 
 #### <a name="ChangeLog"></a>ChangeLog
 
+- 1.11.0
+  - Add `getClient` method to allow retrieving the Cassandra Driver instance from cassanknex.
 - 1.10.1
   - Patch invalid error response when executing commands via an uninitialized Cassandra client.
 - 1.10.0


### PR DESCRIPTION
- Calling `.getClient()` on a cassanKnex instance now returns the Cassandra Client Driver currently in use.