### PR TITLE
Closes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,8 +578,20 @@ cassanKnex.on("ready", function (err) {
 });
 ```
 
+- getDriver, returns the raw Datastax Cassandra Driver dependency module.
+
+```js
+var cassanKnex = require("cassanknex")();
+
+// get the Cassandra Driver
+var driver = cassanKnex.getDriver();
+```
+
 #### <a name="ChangeLog"></a>ChangeLog
 
+- 1.12.0
+  - Add `getDriver` method to allow retrieving the raw DataStax Driver module from cassanknex per issue [#25](https://github.com/azuqua/cassanknex/issues/25).
+  - Update DataStax Driver module from `2.2.1` to `2.2.2`.
 - 1.11.0
   - Add `getClient` method to allow retrieving the Cassandra Driver instance from cassanknex.
 - 1.10.1

--- a/index.js
+++ b/index.js
@@ -65,8 +65,20 @@ CassanKnex.initialize = function (config) {
     return qb;
   }
 
+  /**
+   * Get the cassandra driver currently in use by cassanknex.
+   * @returns {cassandra-driver}
+   */
   cassanKnex.getClient = function () {
     return cassandra;
+  };
+
+  /**
+   * Get the raw datastax cassandra driver module.
+   * @returns {cassandra-driver}
+   */
+  cassanKnex.getDriver = function () {
+    return cassandraDriver;
   };
 
   // Set instance version
@@ -78,6 +90,10 @@ CassanKnex.initialize = function (config) {
     cassanKnex[key] = ee[key];
   }
 
+  /**
+   * Ducks Typing
+   * @returns {string}
+   */
   cassanKnex.toString = function () {
     return duckType;
   };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "austin brown <austin@azuqua.com> (http://www.azuqua.com/)",
   "license": "MIT",
   "dependencies": {
-    "cassandra-driver": "^2.2.1",
+    "cassandra-driver": "^2.2.2",
     "inherits": "^2.0.1",
     "lodash": "^3.10.1"
   },

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -31,4 +31,13 @@ describe("SmokeTest", function () {
       });
   });
 
+  it("should return the datastax cassandra driver module", function () {
+    var cassanKnex = require("../index")({
+      debug: false
+    });
+
+    var driver = cassanKnex.getDriver();
+    assert.ok(driver, "driver ought to be defined");
+  });
+
 });


### PR DESCRIPTION
Now possible to get the raw DataStax Cassandra Driver dependency via the `getDriver` method:

```
var cassanKnex = require("cassanknex")();

// get the Cassandra Driver
var driver = cassanKnex.getDriver();
```