### PR TITLE
ci: fix filter for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,9 @@ workflows:
           matrix:
             parameters:
               node_version: ["10", "12", "14"]
+          filters:
+            tags:
+              only: /^v.*/
       - publish:
           context: org-global
           requires:


### PR DESCRIPTION
Fix the annoyance of having to include a `tags: only: ..` rule in all workflow steps so circleci will recognize the tag cicd run. 