### PR TITLE
ci: use circleci workspaces appropriately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,7 @@ jobs:
     docker:
       - image: circleci/node:14
     steps:
-      - attach_workspace:
-          at: ~/repo
+      - checkout
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc


### PR DESCRIPTION
The last one, promise (crosses-fingers). The example I've been working from used circleci workspaces but not a matrix, I haven't been able to get a good combination or workspaces+matrix working w/o the matrix runs overriding values in the workspace, so I'm falling back to simply check out the code during the publish job.