### PR TITLE
chore: bump version to 1.20.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassanknex",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "An Apache Cassandra CQL query builder with support for the DataStax NodeJS driver, written in the spirit of Knex.",
   "main": "index.js",
   "homepage": "https://github.com/azuqua/cassanknex",


### PR DESCRIPTION
## Description

- I neglected to bump the version number in https://github.com/azuqua/cassanknex/pull/80...

## Testing Details

- [x] Verified basic functionality of change
- [ ] Added tests

For OKTA-420083
