### PR TITLE
WIP: feat: Add SingleRegion Replication Strategy for Aws Keyspaces Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ qb.insert(values)
 - withOptions
 
 ##### <a name="QueryModifiers-Keyspaces"></a>*For keyspace queries*:
+- withSingleRegionStrategy
 - withNetworkTopologyStrategy
 - withSimpleStrategy
 - withDurableWrites

--- a/componentDeclarations/componentBuilderMethods.js
+++ b/componentDeclarations/componentBuilderMethods.js
@@ -44,6 +44,7 @@ module.exports = {
   "keyspace": {
     "withNetworkTopologyStrategy": {"name": "NetworkTopologyStrategy", "grouping": "strategy"},
     "withSimpleStrategy": {"name": "SimpleStrategy", "grouping": "strategy"},
+    "withSingleRegionStrategy": {"name": "SingleRegionStrategy", "grouping": "strategy"},
     "withDurableWrites": {"name": "DURABLE_WRITES", "grouping": "and"}//,
     //"raw": {"name": "raw", "grouping": "raw"}
   },

--- a/schema/keyspaceBuilder.js
+++ b/schema/keyspaceBuilder.js
@@ -33,7 +33,7 @@ _.each(Object.keys(methods), function (method) {
 
 /**
  * Returns function used to build the `with replication` clause in a create keyspace statement
- *
+ * 
  * @param _class
  * @returns {Function}
  * @private
@@ -65,6 +65,9 @@ function _getStrategyGrouping(_class) {
           replication[k] = dataCenterParam[k];
         });
       });
+    }
+    else if (_class === methods.withSingleRegionStrategy.name) {
+      //AWS Keyspace, no replication factor required
     }
 
     this._statements.push({


### PR DESCRIPTION
## Description

- AWS Keyspaces only supports Single Region Strategy so i've added withSingleRegionStrategy function

## Testing Details

- [x] Verified basic functionality of change
- [ ] Added tests

